### PR TITLE
chore: release v1.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.4](https://github.com/oxc-project/javascript-globals/compare/javascript-globals-v1.3.3...javascript-globals-v1.3.4) - 2025-10-29
+
+### Other
+
+- Add Vue, Svelte, and Astro globals ([#106](https://github.com/oxc-project/javascript-globals/pull/106))
+
 ## [1.3.3](https://github.com/oxc-project/javascript-globals/compare/javascript-globals-v1.3.2...javascript-globals-v1.3.3) - 2025-09-10
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "javascript-globals"
-version = "1.3.3"
+version = "1.3.4"
 dependencies = [
  "phf",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "xtask"]
 
 [package]
 name = "javascript-globals"
-version = "1.3.3"
+version = "1.3.4"
 authors = ["Boshen <boshenc@gmail.com>"]
 categories = []
 edition = "2021"


### PR DESCRIPTION



## 🤖 New release

* `javascript-globals`: 1.3.3 -> 1.3.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.3.4](https://github.com/oxc-project/javascript-globals/compare/javascript-globals-v1.3.3...javascript-globals-v1.3.4) - 2025-10-29

### Other

- Add Vue, Svelte, and Astro globals ([#106](https://github.com/oxc-project/javascript-globals/pull/106))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).