### PR TITLE
chore: release v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1](https://github.com/oxc-project/javascript-globals/compare/javascript-globals-v1.4.0...javascript-globals-v1.4.1) - 2026-02-02
+
+### Fixed
+
+- *(ci)* update globals package before running xtask ([#158](https://github.com/oxc-project/javascript-globals/pull/158))
+
 ## [1.4.0](https://github.com/oxc-project/javascript-globals/compare/javascript-globals-v1.3.4...javascript-globals-v1.4.0) - 2026-01-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "javascript-globals"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "phf",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "xtask"]
 
 [package]
 name = "javascript-globals"
-version = "1.4.0"
+version = "1.4.1"
 authors = ["Boshen <boshenc@gmail.com>"]
 categories = []
 edition = "2021"


### PR DESCRIPTION



## 🤖 New release

* `javascript-globals`: 1.4.0 -> 1.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.4.1](https://github.com/oxc-project/javascript-globals/compare/javascript-globals-v1.4.0...javascript-globals-v1.4.1) - 2026-02-02

### Fixed

- *(ci)* update globals package before running xtask ([#158](https://github.com/oxc-project/javascript-globals/pull/158))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).