### PR TITLE
docs: map npm package links to npmx.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 > Global identifiers from different JavaScript environments
 
-Rust fork of https://www.npmjs.com/package/globals
+Rust fork of https://npmx.dev/package/globals


### PR DESCRIPTION
## Summary
- replace npm package links from npmjs.com to https://npmx.dev
- only update documentation files