### PR TITLE
chore: release v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.1](https://github.com/oxc-project/javascript-globals/compare/javascript-globals-v1.5.0...javascript-globals-v1.5.1) - 2026-06-24
+
+### Other
+
+- *(deps)* update rust crates to 0.14.0 ([#231](https://github.com/oxc-project/javascript-globals/pull/231))
+- Auto update globals from upstream ([#232](https://github.com/oxc-project/javascript-globals/pull/232))
+- *(deps)* update rust crate serde_json to v1.0.150 ([#221](https://github.com/oxc-project/javascript-globals/pull/221))
+- Auto update globals from upstream ([#208](https://github.com/oxc-project/javascript-globals/pull/208))
+- Auto update globals from upstream ([#197](https://github.com/oxc-project/javascript-globals/pull/197))
+
 ## [1.5.0](https://github.com/oxc-project/javascript-globals/compare/javascript-globals-v1.4.1...javascript-globals-v1.5.0) - 2026-03-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "javascript-globals"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "phf",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "xtask"]
 
 [package]
 name = "javascript-globals"
-version = "1.5.0"
+version = "1.5.1"
 authors = ["Boshen <boshenc@gmail.com>"]
 categories = []
 edition = "2021"


### PR DESCRIPTION



## 🤖 New release

* `javascript-globals`: 1.5.0 -> 1.5.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.5.1](https://github.com/oxc-project/javascript-globals/compare/javascript-globals-v1.5.0...javascript-globals-v1.5.1) - 2026-06-24

### Other

- *(deps)* update rust crates to 0.14.0 ([#231](https://github.com/oxc-project/javascript-globals/pull/231))
- Auto update globals from upstream ([#232](https://github.com/oxc-project/javascript-globals/pull/232))
- *(deps)* update rust crate serde_json to v1.0.150 ([#221](https://github.com/oxc-project/javascript-globals/pull/221))
- Auto update globals from upstream ([#208](https://github.com/oxc-project/javascript-globals/pull/208))
- Auto update globals from upstream ([#197](https://github.com/oxc-project/javascript-globals/pull/197))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).