### PR TITLE
ci: add crates environment to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
   release-plz:
     name: Release-plz
     runs-on: ubuntu-latest
+    environment: crates
     permissions:
       pull-requests: write
       contents: write

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Rust fork of https://npmx.dev/package/globals
 ## Available Environments
 
 <!-- GENERATED-ENV-LIST:START - Do not remove or modify this section -->
+
 - `builtin`
 - `es6`
 - `es2015`
@@ -50,4 +51,5 @@ Rust fork of https://npmx.dev/package/globals
 - `qunit`
 - `vitest`
 - `vue`
+
 <!-- GENERATED-ENV-LIST:END -->

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,11 +1,10 @@
-lockfileVersion: '9.0'
+lockfileVersion: "9.0"
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 importers:
-
   .:
     devDependencies:
       globals:
@@ -13,11 +12,11 @@ importers:
         version: 17.7.0
 
 packages:
-
   globals@17.7.0:
-    resolution: {integrity: sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==}
-    engines: {node: '>=18'}
+    resolution: {
+      integrity: sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==,
+    }
+    engines: { node: ">=18" }
 
 snapshots:
-
   globals@17.7.0: {}


### PR DESCRIPTION
Adds `environment: crates` to the `release-plz` job in `.github/workflows/release.yml` so releases run through the crates environment.
