### PR TITLE
fix(xtask): generate README env list in dprint-compatible format

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -291,8 +291,10 @@ fn update_readme(env_names: &[&str]) {
         .map(|name| format!("- `{name}`\n"))
         .collect();
 
+    // Surround the list with blank lines so the output matches `dprint fmt`'s
+    // markdown formatting; otherwise xtask and dprint fight over README.md.
     let new_readme = format!(
-        "{}{start_marker}\n{env_list}{end_marker}{}",
+        "{}{start_marker}\n\n{env_list}\n{end_marker}{}",
         &readme[..start],
         &readme[end + end_marker.len()..],
     );


### PR DESCRIPTION
## Problem

CI on `main` is failing in the **Test** job at `git diff --exit-code` after `cargo run -p xtask`.

`xtask` regenerates the `<!-- GENERATED-ENV-LIST -->` section of `README.md` with **no** blank lines around the list, but `dprint fmt` (run via `just fmt` in the autofix workflow) **adds** blank lines surrounding the list. The committed `README.md` is the dprint-formatted version, so the Test job — which runs xtask but not dprint — sees xtask strip those blank lines and fails:

```diff
 <!-- GENERATED-ENV-LIST:START - Do not remove or modify this section -->
-
 - `builtin`
 ...
 - `vue`
-
 <!-- GENERATED-ENV-LIST:END -->
```

## Fix

Emit the surrounding blank lines from `xtask` so its output matches `dprint fmt`. The two tools now agree, so xtask is idempotent under dprint and the Test job's `git diff --exit-code` passes. This also makes the auto-update workflow's generated PRs dprint-stable without relying on autofix.

Verified locally: after the change, `cargo run -p xtask` produces no diff against the committed README, and `dprint check` reports no changes.