### PR TITLE
chore: configure clippy exported api lint

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,1 @@
+avoid-breaking-exported-api = false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,11 +1,10 @@
-lockfileVersion: '9.0'
+lockfileVersion: "9.0"
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 importers:
-
   .:
     devDependencies:
       globals:
@@ -13,11 +12,11 @@ importers:
         version: 17.7.0
 
 packages:
-
   globals@17.7.0:
-    resolution: {integrity: sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==}
-    engines: {node: '>=18'}
+    resolution: {
+      integrity: sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==,
+    }
+    engines: { node: ">=18" }
 
 snapshots:
-
   globals@17.7.0: {}


### PR DESCRIPTION
Ensures clippy is clean with `avoid-breaking-exported-api = false`.

Validated with `cargo clippy --workspace --all-targets --all-features`.
