### PR TITLE
chore: standardize rustfmt config

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,6 @@
+style_edition = "2024"
+use_small_heuristics = "Max"
+use_field_init_shorthand = true
+reorder_modules = true
+merge_derives = true
+remove_nested_parens = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,9 +37,7 @@ impl Index<&str> for Globals {
     type Output = phf::Map<&'static str, bool>;
 
     fn index(&self, key: &str) -> &Self::Output {
-        self.0
-            .get(key)
-            .unwrap_or_else(|| panic!("unknown environment: {key}"))
+        self.0.get(key).unwrap_or_else(|| panic!("unknown environment: {key}"))
     }
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -178,13 +178,8 @@ fn main() {
     .map(|(name, vars)| Env {
         name,
         vars: {
-            let mut v: Vec<_> = vars
-                .iter()
-                .map(|(key, value)| EnvVar {
-                    name: key,
-                    writable: *value,
-                })
-                .collect();
+            let mut v: Vec<_> =
+                vars.iter().map(|(key, value)| EnvVar { name: key, writable: *value }).collect();
             v.sort_by_key(|e| e.name);
             v
         },
@@ -252,9 +247,7 @@ impl Index<&str> for Globals {{
     type Output = phf::Map<&'static str, bool>;
 
     fn index(&self, key: &str) -> &Self::Output {{
-        self.0
-            .get(key)
-            .unwrap_or_else(|| panic!("unknown environment: {{key}}"))
+        self.0.get(key).unwrap_or_else(|| panic!("unknown environment: {{key}}"))
     }}
 }}
 
@@ -279,17 +272,10 @@ fn update_readme(env_names: &[&str]) {
     let start_marker = "<!-- GENERATED-ENV-LIST:START - Do not remove or modify this section -->";
     let end_marker = "<!-- GENERATED-ENV-LIST:END -->";
 
-    let start = readme
-        .find(start_marker)
-        .expect("Could not find start marker in README.md");
-    let end = readme
-        .find(end_marker)
-        .expect("Could not find end marker in README.md");
+    let start = readme.find(start_marker).expect("Could not find start marker in README.md");
+    let end = readme.find(end_marker).expect("Could not find end marker in README.md");
 
-    let env_list: String = env_names
-        .iter()
-        .map(|name| format!("- `{name}`\n"))
-        .collect();
+    let env_list: String = env_names.iter().map(|name| format!("- `{name}`\n")).collect();
 
     // Surround the list with blank lines so the output matches `dprint fmt`'s
     // markdown formatting; otherwise xtask and dprint fight over README.md.


### PR DESCRIPTION
Standardizes the Rustfmt config filename and options, then applies cargo fmt.
