### PR TITLE
ci(semgrep): add scan workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,26 @@
+name: Semgrep
+
+permissions: {}
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize]
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
+
+jobs:
+  semgrep:
+    name: Semgrep
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep:1.170.0
+    steps:
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+
+      - run: semgrep scan --config auto

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,11 +1,10 @@
-lockfileVersion: '9.0'
+lockfileVersion: "9.0"
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 importers:
-
   .:
     devDependencies:
       globals:
@@ -13,11 +12,11 @@ importers:
         version: 17.7.0
 
 packages:
-
   globals@17.7.0:
-    resolution: {integrity: sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==}
-    engines: {node: '>=18'}
+    resolution: {
+      integrity: sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==,
+    }
+    engines: { node: ">=18" }
 
 snapshots:
-
   globals@17.7.0: {}


### PR DESCRIPTION
## Summary

- add Semgrep CE scans for pull requests and pushes to `main`
- pin Semgrep to v1.170.0
- use the repository's pinned `taiki-e/checkout-action` and concurrency convention

## Testing

- use the workflow already validated in `oxc-project/oxc`
- verify the pull request with GitHub Actions before merging

## AI usage

This change was implemented with assistance from OpenAI OpenCode. The contributor remains responsible for reviewing and understanding the change.